### PR TITLE
Add tessel to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "homepage": "https://github.com/rwaldron/tessel-io",
   "dependencies": {
     "array-includes": "^2.0.0",
-    "es6-shim": "^0.32.1"
+    "es6-shim": "^0.32.1",
+    "tessel": "^0.3.23"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
I had to npm install tessel locally to use tessel-io. Shouldn't it be a dependency?