### PR TITLE
Support for the onboard LEDs

### DIFF
--- a/lib/tessel.js
+++ b/lib/tessel.js
@@ -58,7 +58,7 @@ var portOffsets = {
     A: 0,
     B: 8,
     L: 16
-}
+};
 
 var analogPins = [
   4, 7, 8, 9, 10, 11, 12, 13, 14, 15
@@ -237,7 +237,7 @@ function Pin(options) {
         if (value === 1 || value === 3 || value === 4) {
           // TODO: Make sure this doesn't
           // interfere with pwmWrite
-          if(options.port !== "L") {
+          if (options.port !== "L") {
             pin.output();
           }
         }

--- a/lib/tessel.js
+++ b/lib/tessel.js
@@ -198,12 +198,7 @@ function Pin(options) {
   // options.port
   // options.index
   
-  console.log("Port, index", options.port, options.index);
-  
   var pin = options.port === "L" ? tessel.led[options.index] : tessel.port[options.port].pin[options.index];
-  
-  console.log("PIN: ", pin);
-  
   var state = {
     isAnalog: false,
     pin: pin,
@@ -420,7 +415,6 @@ Tessel.prototype.digitalRead = function(pin, handler) {
 };
 
 Tessel.prototype.digitalWrite = function(pin, value) {
-  console.log("WRITE IT: ", pin, value);
   this.pins[ToPinIndex(pin)].write(constrain(value, 0, 1));
   return this;
 };

--- a/lib/tessel.js
+++ b/lib/tessel.js
@@ -47,7 +47,18 @@ var pinModes = [
   { modes: [0, 1, 2, 3, 4, ], analogChannel: 7 },
   { modes: [0, 1, 2, 3, 4, ], analogChannel: 8 },
   { modes: [0, 1, 2, 3 ], analogChannel: 9 },
+  // LEDs
+  { modes: [1] },
+  { modes: [1] },
+  { modes: [1] },
+  { modes: [1] },
 ];
+
+var portOffsets = {
+    A: 0,
+    B: 8,
+    L: 16
+}
 
 var analogPins = [
   4, 7, 8, 9, 10, 11, 12, 13, 14, 15
@@ -68,9 +79,9 @@ function ToPinIndex(value) {
 
   var port = value[0].toUpperCase();
   var pin = +value[1];
-  var offset = port === "A" ? 0 : 8;
+  var offset = portOffsets[port];
 
-  if (port !== "A" && port !== "B") {
+  if (port !== "A" && port !== "B" && port !== "L") {
     return -1;
   }
 
@@ -88,9 +99,11 @@ function ToPortIdentity(pinIndex) {
   }
 
   var isPortB = pinIndex > 7;
-  var offset = isPortB ? 8 : 0;
+  var isLED = pinIndex > 15;
+  var port = isLED ? "L" : isPortB ? "B" : "A"; 
+  var offset = portOffsets[port];
   return {
-    port: isPortB ? "B" : "A",
+    port: port,
     index: pinIndex - offset,
   };
 }
@@ -184,11 +197,17 @@ Port.REPLY = {
 function Pin(options) {
   // options.port
   // options.index
-  var pin = tessel.port[options.port].pin[options.index];
+  
+  console.log("Port, index", options.port, options.index);
+  
+  var pin = options.port === "L" ? tessel.led[options.index] : tessel.port[options.port].pin[options.index];
+  
+  console.log("PIN: ", pin);
+  
   var state = {
     isAnalog: false,
     pin: pin,
-    index: (options.port === "B" ? 8 : 0) + pin.pin,
+    index: portOffsets[options.port] + options.index,
     mode: 0
   };
 
@@ -223,7 +242,9 @@ function Pin(options) {
         if (value === 1 || value === 3 || value === 4) {
           // TODO: Make sure this doesn't
           // interfere with pwmWrite
-          pin.output();
+          if(options.port !== "L") {
+            pin.output();
+          }
         }
 
         state.isAnalog = value === 2;
@@ -399,6 +420,7 @@ Tessel.prototype.digitalRead = function(pin, handler) {
 };
 
 Tessel.prototype.digitalWrite = function(pin, value) {
+  console.log("WRITE IT: ", pin, value);
   this.pins[ToPinIndex(pin)].write(constrain(value, 0, 1));
   return this;
 };

--- a/test/tessel-mock.js
+++ b/test/tessel-mock.js
@@ -14,6 +14,7 @@ function Tessel() {
     B: new Tessel.Port("B", "/var/run/tessel/port_b", this)
   };
   this.port = this.ports;
+  this.led = new Tessel.Port("L", "/var/run/tessel/port_l", this);
 
   // tessel v1 does not have this version number
   // this is useful for libraries to adapt to changes

--- a/test/tessel.js
+++ b/test/tessel.js
@@ -112,7 +112,7 @@ exports["TesselIO Constructor"] = {
   pins: function(test) {
     // test.expect();
 
-    test.equal(this.tessel.pins.length, 16);
+    test.equal(this.tessel.pins.length, 20);
     test.equal(this.tessel.analogPins.length, 10);
     test.done();
   },
@@ -158,7 +158,7 @@ exports["ToPinIndex"] = {
   invalidIndex: function(test) {
     test.expect(2);
     test.equal(ToPinIndex(-1), -1);
-    test.equal(ToPinIndex(16), -1);
+    test.equal(ToPinIndex(20), -1);
     test.done();
   },
 
@@ -195,7 +195,7 @@ exports["ToPortIdentity"] = {
   invalid: function(test) {
     test.expect(2);
     test.deepEqual(ToPortIdentity(-1), { port: null, index: -1 });
-    test.deepEqual(ToPortIdentity(16), { port: null, index: -1 });
+    test.deepEqual(ToPortIdentity(20), { port: null, index: -1 });
     test.done();
   },
 };


### PR DESCRIPTION
Based on this question: https://github.com/rwaldron/tessel-io/issues/5

This allows us to use the LEDs as digital write pins:

```
// Via J5, but they are really just exposed as digital write pins
board.on("ready", function() {
    var led1 = new five.Led("l2");
    var led2 = new five.Led("l3");
    
    led1.blink();
    led2.blink();  
});
```