### PR TITLE
Board control: Detect execution on Tessel via path check

### DIFF
--- a/lib/tessel.js
+++ b/lib/tessel.js
@@ -6,9 +6,34 @@ var Emitter = require("events").EventEmitter;
 var tessel;
 var factory;
 
+/**
+ * dirName gets or sets the current value of `__dirname`
+ *
+ * Normally, we would never want to set the value of `__dirname`. The only
+ * reason that we're including this functionality is to expose it for testing
+ * purposes.
+ *
+ * A later check against the current directory is used to enforce REPL
+ * disabling, and so we expose this function on `Tessel` when in a testing
+ * environment, in order to allow the test to mock the value of `__dirname` for
+ * the Tessel's execution environments.
+ *
+ * @returns {String} The current value of __dirname
+ */
+function dirName(newPath) {
+  if (typeof newPath !== "undefined") {
+    /*jshint -W020 */
+    __dirname = newPath;
+    /*jshint +W020 */
+  }
+
+  return __dirname;
+}
+
 if (process.env.IS_TEST_ENV) {
   factory = require("../test/tessel-mock");
   tessel = factory();
+  Tessel.dirName = dirName;
 } else {
   tessel = require("tessel");
 }
@@ -430,6 +455,11 @@ function Tessel(options) {
   this.pins = pinModes.map((config, index) => {
     return new Pin(Object.assign({}, config, ToPortIdentity(index)));
   });
+
+  // If we detect that we're running on-board the Tessel, disable the repl
+  if (dirName().startsWith("/app/remote-script")) {
+    this.repl = false;
+  }
 
   // Necessary for coordinating mult-board support.
   tessels.push(this);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Tessel 2 IO Plugin for Johnny-Five JavaScript Robotics",
   "main": "lib/tessel.js",
   "scripts": {
-    "test": "grunt nodeunit"
+    "test": "grunt"
   },
   "repository": {
     "type": "git",

--- a/test/tessel.js
+++ b/test/tessel.js
@@ -233,6 +233,40 @@ exports["Tessel Constructor"] = {
 
 };
 
+exports["Automatic REPL disabling"] = {
+  setUp: function(done) {
+    this.dirName = Tessel.dirName();
+    done();
+  },
+  tearDown: function(done) {
+    Tessel.purge();
+    Tessel.dirName(this.dirName);
+    done();
+  },
+
+  checkT2Run: function(test) {
+    test.expect(1);
+
+    Tessel.dirName("/tmp/remote-script");
+    var tessel = new Tessel();
+
+    test.equal(tessel.repl, undefined);
+
+    test.done();
+  },
+
+  checkT2Push: function(test) {
+    test.expect(1);
+
+    Tessel.dirName("/app/remote-script");
+    var tessel = new Tessel();
+
+    test.equal(tessel.repl, false);
+
+    test.done();
+  }
+};
+
 
 exports["ToPinIndex"] = {
   valid: function(test) {


### PR DESCRIPTION
I believe this satisfies the request in #8 - I would have used `process.cwd()` but I didn't get the expected results (see https://github.com/rwaldron/tessel-io/issues/8#issuecomment-211633556 for details).

I also added the ability for explicitly setting it to whatever value, in the event that at some point, someone wants to forcibly turn on the repl for some reason. It seemed reasonable but I can cut it out.

Looking forward to feedback. :)