### PR TITLE
load correct io module

### DIFF
--- a/eg/analog-read.js
+++ b/eg/analog-read.js
@@ -1,5 +1,5 @@
 // process.env.IS_TEST_MODE = true;
-var Tessel = require("../lib/tessel");
+var Tessel = require("../lib/index");
 var board = new Tessel();
 
 board.on("ready", function() {

--- a/eg/digital-read.js
+++ b/eg/digital-read.js
@@ -1,5 +1,5 @@
 // process.env.IS_TEST_MODE = true
-var Tessel = require("../lib/tessel");
+var Tessel = require("../lib/index");
 var board = new Tessel();
 
 board.on("ready", function() {

--- a/eg/digital-write.js
+++ b/eg/digital-write.js
@@ -1,5 +1,5 @@
 // process.env.IS_TEST_MODE = true;
-var Tessel = require("../lib/tessel");
+var Tessel = require("../lib/index");
 var board = new Tessel();
 
 board.on("ready", function() {

--- a/eg/i2c-blinkm-controller.js
+++ b/eg/i2c-blinkm-controller.js
@@ -1,5 +1,5 @@
 // process.env.IS_TEST_MODE = true;
-var Tessel = require("../lib/tessel");
+var Tessel = require("../lib/index");
 var board = new Tessel();
 
 var BlinkM = {

--- a/eg/muilt-function.js
+++ b/eg/muilt-function.js
@@ -1,4 +1,4 @@
-var Tessel = require("../lib/tessel");
+var Tessel = require("../lib/index");
 var board = new Tessel();
 
 board.on("ready", function() {

--- a/eg/onboard-led.js
+++ b/eg/onboard-led.js
@@ -1,5 +1,5 @@
 // process.env.IS_TEST_MODE = true;
-var Tessel = require("../lib/tessel.js");
+var Tessel = require("../lib/index");
 var board = new Tessel();
 
 board.on("ready", function() {

--- a/eg/pwm-write.js
+++ b/eg/pwm-write.js
@@ -1,5 +1,5 @@
 // process.env.IS_TEST_MODE = true;
-var Tessel = require("../lib/tessel");
+var Tessel = require("../lib/index");
 var board = new Tessel();
 
 board.on("ready", function() {


### PR DESCRIPTION
fixed the `require`'s in the examples to load `lib/index` instead of `lib/tessel` (which no longer exists).